### PR TITLE
use a few simple TypeScript features

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,7 @@ import * as u from './util'
 const EventEmitter = require('events')
 const Hookable = require('hoox')
 
-const identity = (x: any): any => x
+const identity = (x: unknown): unknown => x
 
 function merge (a: any, b: any, mapper?: any) {
   mapper = mapper ?? identity

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,8 @@
 import Api = require('./api')
 
 // config must have appKey
-export = function SecretStack (config: any) {
-  // this weird thing were some config is loaded first,
-  // then the rest later... not necessary.
-  config = config ?? {}
-  config.permissions = config.permissions ?? {}
-
-  const plugin = {
-    permissions: config.permissions,
-    init: function () {}
-  }
-
-  // weird that this passes a mostly empty plugin in here?
-  const create = Api([plugin], config)
+export = function SecretStack (config: unknown) {
+  const create = Api([], config ?? {})
 
   return (
     create

--- a/src/plugins/net.ts
+++ b/src/plugins/net.ts
@@ -4,9 +4,8 @@ const debug = require('debug')('secret-stack net plugin')
 export = {
   name: 'multiserver-net',
   version: '1.0.0',
-  manifest: {},
-  init (ssk: any) {
-    ssk.multiserver.transport({
+  init (api: any) {
+    api.multiserver.transport({
       name: 'net',
       create: (opts: any) => {
         debug(
@@ -20,4 +19,4 @@ export = {
       }
     })
   }
-};
+}

--- a/src/plugins/shs.ts
+++ b/src/plugins/shs.ts
@@ -20,7 +20,6 @@ function toSodiumKeys (keys: any) {
 export = {
   name: 'multiserver-shs',
   version: '1.0.0',
-  mainfest: {},
   init (api: any, config: any) {
     let timeoutHandshake: number
     if (config.timers && !isNaN(config.timers.handshake)) {
@@ -42,7 +41,7 @@ export = {
       seed: config.seed,
       appKey: toBuffer(shsCap),
       timeout: timeoutHandshake,
-      authenticate: function (pub: any, cb: Function) {
+      authenticate: function (pub: string, cb: Function) {
         const id = '@' + u.toId(pub)
         api.auth(id, function (err: any, auth: any) {
           if (err) cb(err)
@@ -60,4 +59,4 @@ export = {
       create: () => shs
     })
   }
-};
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,12 @@
 const mapMerge = require('map-merge')
 const camelize = require('to-camel-case')
 
-function isObject (o: any) {
+function isObject (o: unknown): o is Record<string, unknown> {
   return o && typeof o === 'object'
 }
 
-export function clone (obj: any, mapper: any): any {
-  function map (v: any, k?: string | number) {
+export function clone (obj: unknown, mapper: any): any {
+  function map (v: unknown, k?: string | number) {
     return isObject(v) ? clone(v, mapper) : mapper(v, k)
   }
   if (Array.isArray(obj)) {
@@ -27,13 +27,13 @@ export function toId (pub: Buffer | string) {
 }
 
 export const merge = {
-  permissions (perms: any, _perms: any, name?: string) {
+  permissions (perms: unknown, _perms: unknown, name?: string) {
     return mapMerge(
       perms,
       clone(_perms, (v: any) => name ? name + '.' + v : v)
     )
   },
-  manifest (manf: any, _manf: any, name?: string) {
+  manifest (manf: unknown, _manf: unknown, name?: string) {
     if (name) {
       const o: any = {}
       o[name] = _manf
@@ -46,7 +46,7 @@ export const merge = {
 export function hookOptionalCB (syncFn: any) {
   // syncFn is a function that's expected to return its result or throw an error
   // we're going to hook it so you can optionally pass a callback
-  syncFn.hook(function (this: any, fn: any, args: Array<any>) {
+  syncFn.hook(function (this: unknown, fn: Function, args: Array<unknown>) {
     // if a function is given as the last argument, treat it as a callback
     const cb = args[args.length - 1]
     if (typeof cb === 'function') {


### PR DESCRIPTION
- Replace `any` with `unknown`
  
  The TypeScript `any` type means that `foo: any` allows you to do `foo.x.y` and it will not emit any compilation errors. But `foo: unknown` allows you to use `foo` but **disallows** you to use `foo.x` or `foo.x.y`, e.g. you could do `console.log(foo)` but you couldn't do `console.log(foo.x)`. This is useful because `unknown` is somewhat loose (you don't have to specify **exactly** what the type of the thing is), but not too loose. `console.log(foo)` is always safe (will never crash JavaScript), but `console.log(foo.x)` **may** cause a "x is not a property of undefined" crash in JavaScript. So by sprinkling `unknown` here and there, we're progressively making the codebase safer against such runtime errors.

- Other changes I'll comment inline since they are specific