### PR TITLE
add TypeScript types for the config object

### DIFF
--- a/src/plugins/shs.ts
+++ b/src/plugins/shs.ts
@@ -1,4 +1,5 @@
 import * as u from '../util'
+import { Config } from '../types'
 const Shs = require('multiserver/plugins/shs')
 
 function toBuffer (base64: string | Buffer): Buffer {
@@ -7,8 +8,8 @@ function toBuffer (base64: string | Buffer): Buffer {
   return Buffer.from(~i ? base64.substring(0, i) : base64, 'base64')
 }
 
-function toSodiumKeys (keys: any) {
-  if (!(typeof keys.public === 'string' && typeof keys.private === 'string')) {
+function toSodiumKeys (keys: NonNullable<Config['keys']>) {
+  if (typeof keys.public !== 'string' || typeof keys.private !== 'string') {
     return keys
   }
   return {
@@ -20,12 +21,14 @@ function toSodiumKeys (keys: any) {
 export = {
   name: 'multiserver-shs',
   version: '1.0.0',
-  init (api: any, config: any) {
-    let timeoutHandshake: number
-    if (config.timers && !isNaN(config.timers.handshake)) {
-      timeoutHandshake = config.timers.handshake
+  init (api: any, config: Config) {
+    let timeoutHandshake: number | undefined
+    if (!isNaN(config.timers?.handshake as any)) {
+      timeoutHandshake = config.timers?.handshake!
     }
-    timeoutHandshake = timeoutHandshake! || (config.timers ? 15e3 : 5e3)
+    if (!timeoutHandshake) {
+      timeoutHandshake = (config.timers ? 15e3 : 5e3)
+    }
     // set all timeouts to one setting, needed in the tests.
     if (config.timeout) {
       timeoutHandshake = config.timeout

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,40 @@ export type Transform = {
   name: string;
   create: () => unknown;
 };
+
+export type Config = {
+  // Cryptographic capability key
+  caps?: {
+    shs?: Buffer | string;
+  };
+  appKey?: Buffer | string;
+
+  // Cryptographic keys
+  keys?: {
+    public?: string;
+    private?: string;
+    id?: string;
+  };
+  seed?: unknown;
+
+  // Multiserver
+  connections?: {
+    incoming?: {
+      [name: string]: Array<Incoming>;
+    };
+    outgoing?: {
+      [name: string]: Array<Outgoing>;
+    };
+  };
+
+  // Timers
+  timeout?: number;
+  timers?: {
+    handshake?: number;
+    inactivity?: number;
+  };
+
+  // Legacy but still supported
+  host?: string;
+  port?: number;
+};


### PR DESCRIPTION
Review by reading first `src/types.ts` and then the other files. Previously, config was an `any` object, which allows all kinds of objects, but also numbers, strings, undefined, etc. This PR should add some protection against typos, as well as rigorously checking against undefined and null cases possibly existing in config object.