### PR TITLE
update mkdirp and old minimist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1459,18 +1459,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -2552,14 +2552,6 @@
         "get-stdin": "^7.0.0",
         "minimist": "^1.2.5",
         "pkg-conf": "^3.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "standardx": {
@@ -2846,14 +2838,6 @@
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/parser": "^3.5.0",
     "pull-pushable": "^2.0.1",
     "ssb-keys": "^7.1.5",
+    "mkdirp": "~0.5.5",
     "standardx": "^5.0.0",
     "tape": "^4.0.0",
     "typescript": "~3.9.5"


### PR DESCRIPTION
There's a security alert about `minimist`, which is old only for old versions of `mkdirp`. I'm pretty sure these are not used in secret-stack *other* than for devDeps and build-time scripts, but it's good to anyway update so that we explicitly have zero security issues raised.

I'll merge this if no one reviews in 48h after PR creation.