### PR TITLE
make manifest a public muxrpc API

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -106,6 +106,11 @@ export = {
       address: 'sync'
     }
   },
+  permissions: {
+    anonymous: {
+      allow: ['manifest']
+    }
+  },
   init (api: any, opts: Config, permissions: any, manifest: any) {
     let timeoutInactivity: number
     if (!isNaN(opts.timers?.inactivity as any)) {


### PR DESCRIPTION
## Context

[Manifest bootstrapping](https://github.com/ssb-js/muxrpc/#bootstrapping---automatically-loading-the-remote-manifest) has been a muxrpc feature since [Dec 2017](https://github.com/ssb-js/muxrpc/pull/37), but its usage hasn't been effectively enabled in the SSB ecosystem, and that's because [secret-stack actually just assumes the remote peer has the same manifest as the local peer](https://github.com/ssb-js/secret-stack/blob/113efba0cfba73a6eebce8aa01b18d7d6ae5f3d2/src/core.ts#L229). Anyway, this feature has been possible for others to use because secret-stack [implements](https://github.com/ssb-js/secret-stack/blob/113efba0cfba73a6eebce8aa01b18d7d6ae5f3d2/src/core.ts#L103) [it](https://github.com/ssb-js/secret-stack/blob/113efba0cfba73a6eebce8aa01b18d7d6ae5f3d2/src/core.ts#L275) as a muxrpc API.

## Problem

One specific solution to a specific problem in go-ssb has been to use manifest bootstrapping on remote peers (possible and often JS peers) in order to know what muxrpc methods can be called.

Unfortunately, upon go-ssb attempting to call `manifest()` on a remote JS peer, we got the following error logged in go-ssb:

```
Apr 16 14:30:55 hermiesclub gossbroom[18542]: level=warn remote="IPADDR:PORT|@SSB
FEED=.ed25519" call=manifest reqID=1 event="manifest request failed to read" err=
"muxrpc CallError: Error - method:manifest is not in list of allowed methods"
```

## Solution

We need to make the `manifest` muxrpc method publicly accessible to "anonymous" peers. I tested this change in production and the above go-ssb error does not show anymore.